### PR TITLE
release: v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # AuthKit SDK for SvelteKit
 
-> [!WARNING]
-> This is prerelease software. APIs may change without notice.
-
 The official WorkOS AuthKit SDK for SvelteKit applications. Provides seamless authentication with minimal setup.
+
+> **Looking for a complete example?** Check out the [example app](./example) in this repo.
 
 ## Features
 
@@ -29,7 +28,7 @@ Create a `.env` file in your project root:
 ```env
 WORKOS_CLIENT_ID=client_01234567890123456789012345
 WORKOS_API_KEY=sk_test_1234567890
-WORKOS_REDIRECT_URI=http://localhost:5173/auth/callback
+WORKOS_REDIRECT_URI=http://localhost:5173/callback
 WORKOS_COOKIE_PASSWORD=your-secure-password-at-least-32-chars
 ```
 
@@ -72,12 +71,16 @@ export const handle = authKitHandle();
 
 ### 4. Create Callback Route
 
-Create `src/routes/auth/callback/+server.ts`:
+Create `src/routes/callback/+server.ts`:
 
 ```typescript
 import { authKit } from '@workos/authkit-sveltekit';
+import type { RequestHandler } from './$types';
 
-export const GET = authKit.handleCallback();
+export const GET: RequestHandler = async (event) => {
+  const handler = authKit.handleCallback();
+  return handler(event);
+};
 ```
 
 ### 5. Protect Routes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos/authkit-sveltekit",
-  "version": "0.0.1-alpha.1",
+  "version": "0.1.0",
   "description": "Official WorkOS AuthKit SDK for SvelteKit",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Bump version to v0.1.0 for initial stable release.

### Included in this release
- Upgrade to `@workos/authkit-session` v0.3.4
- Fix return_to redirect bug (#5)
- Add example SvelteKit app with pnpm workspace
- Replace coana workflows with socket-tier1-analysis