### PR TITLE
fix: prevent open redirect in OAuth callback (CWE-601)

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -141,11 +141,20 @@ export function createHandleCallback(authKitInstance: AuthKitInstance) {
           state,
         });
 
-        // Create response with redirect to the return path
+        // Prevent open redirects (CWE-601): `result.returnPathname` was decoded
+        // from the OAuth `state` parameter and is attacker-influenceable. Parse
+        // it against a throwaway origin so the WHATWG URL parser strips any
+        // host, scheme, backslash trick, or tab/newline smuggle; then emit a
+        // RELATIVE Location so the browser resolves against the public callback
+        // URL (correct behind proxies that don't reconstruct `event.url`'s
+        // origin). The leading-slash normalization prevents a crafted pathname
+        // like `//evil.com` from being served as a protocol-relative redirect.
+        const parsedReturn = new URL(result.returnPathname || '/', 'https://placeholder.invalid');
+        const safePath = '/' + parsedReturn.pathname.replace(/^\/+/, '');
         const response = new Response(null, {
           status: 302,
           headers: {
-            Location: result.returnPathname,
+            Location: `${safePath}${parsedReturn.search}${parsedReturn.hash}`,
           },
         });
 

--- a/src/tests/open-redirect.test.ts
+++ b/src/tests/open-redirect.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { RequestEvent } from '@sveltejs/kit';
+import { createHandleCallback } from '../server/auth.js';
+
+type AuthKitInstance = Parameters<typeof createHandleCallback>[0];
+
+function makeEvent(callbackUrl: string): RequestEvent {
+  return {
+    url: new URL(callbackUrl),
+    request: new Request(callbackUrl),
+  } as unknown as RequestEvent;
+}
+
+function makeInstance(returnPathname: string): AuthKitInstance {
+  return {
+    handleCallback: vi.fn().mockResolvedValue({
+      returnPathname,
+      response: new Response(),
+      headers: {},
+    }),
+  } as unknown as AuthKitInstance;
+}
+
+const TRUSTED_ORIGIN = 'https://trusted.example.com';
+const CALLBACK_URL = `${TRUSTED_ORIGIN}/auth/callback?code=abc&state=xyz`;
+
+describe('handleCallback open-redirect protection (CWE-601)', () => {
+  const attackPayloads: Array<[string, string]> = [
+    ['absolute URL to evil host', 'https://evil.com/steal'],
+    ['protocol-relative URL', '//evil.com/steal'],
+    ['backslash smuggle', '/\\evil.com/path'],
+    ['javascript: scheme', 'javascript:alert(1)'],
+    ['empty string', ''],
+    ['tab smuggling', '/\tevil.com'],
+    ['newline smuggling', '/\nevil.com'],
+  ];
+
+  it.each(attackPayloads)('keeps %s on the trusted origin', async (_desc, returnPathname) => {
+    const handler = createHandleCallback(makeInstance(returnPathname))();
+    const response = await handler(makeEvent(CALLBACK_URL));
+
+    const location = response.headers.get('Location')!;
+    // Location must be relative (proxy-safe — browser resolves against the
+    // public callback URL) and must not be a protocol-relative URL.
+    expect(location.startsWith('/')).toBe(true);
+    expect(location.startsWith('//')).toBe(false);
+
+    const resolved = new URL(location, TRUSTED_ORIGIN);
+    expect(resolved.origin).toBe(TRUSTED_ORIGIN);
+    expect(resolved.host).not.toBe('evil.com');
+  });
+
+  it('preserves legitimate pathname + query', async () => {
+    const handler = createHandleCallback(makeInstance('/dashboard?tab=settings'))();
+    const response = await handler(makeEvent(CALLBACK_URL));
+
+    expect(response.headers.get('Location')).toBe('/dashboard?tab=settings');
+  });
+
+  it('preserves hash fragments', async () => {
+    const handler = createHandleCallback(makeInstance('/dashboard#billing'))();
+    const response = await handler(makeEvent(CALLBACK_URL));
+
+    expect(response.headers.get('Location')).toBe('/dashboard#billing');
+  });
+
+  it('emits a relative Location (safe behind proxies that do not rewrite event.url)', async () => {
+    const handler = createHandleCallback(makeInstance('/dashboard'))();
+    // Simulate a proxied request where event.url carries an internal backend
+    // origin rather than the public one.
+    const response = await handler(makeEvent('http://internal-backend.local:3000/auth/callback?code=a&state=b'));
+
+    const location = response.headers.get('Location')!;
+    expect(location).toBe('/dashboard');
+    // Crucially, no backend host leaks into the Location header.
+    expect(location).not.toContain('internal-backend.local');
+  });
+});


### PR DESCRIPTION
## Summary

- `handleCallback` was writing the OAuth state's `returnPathname` directly into the `Location` header. Because `state` round-trips through the IdP and is attacker-influenceable, crafted values (`https://evil.com`, `//evil.com`, `/\evil.com`) redirected victims off-origin after a successful sign-in — a credential-phishing primitive (CWE-601).
- Ports the authkit-nextjs mitigation: parse the untrusted `returnPathname` against a throwaway origin so the WHATWG URL parser strips any host, scheme, or backslash trick, then emit a **relative** `Location` built from `pathname + search + hash` with a leading-slash normalization that defuses the `//evil.com` protocol-relative case.
- Relative (not absolute) `Location` avoids a deployment footgun: behind proxies/TLS terminators that don't rewrite `event.url`'s origin, an absolute Location would leak an internal backend host. The browser resolves the relative path against the public callback URL instead.
- Hash fragments preserved, so `/dashboard#billing` still lands on the right anchor / client-side route.