### PR TITLE
chore: release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos/authkit-sveltekit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official WorkOS AuthKit SDK for SvelteKit",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Version bump to **0.3.0**. Ships #17 (per-flow PKCE cookies via authkit-session 0.5.1).

### Included since v0.2.0

- #17 `feat(auth): adopt per-flow PKCE cookies (authkit-session 0.5.1)` — threads `state` into `clearPendingVerifier` so each sign-in flow gets an isolated verifier cookie; adds README guidance on reserving `withAuth` for HTML routes; guards `clearPendingVerifier` against storage throws so bail paths always return their redirect.

Minor bump: additive capability, public API (`createHandleCallback`, `withAuth`) unchanged.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: tag `v0.3.0` and publish a GitHub release to trigger the `release.yml` workflow → `pnpm publish --tag latest` with provenance
- [ ] Verify the published package on npm lists `@workos/authkit-session ^0.5.1` as a dependency