### PR TITLE
ci: route release publish install through Socket Firewall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
   pull_request: {}
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -19,6 +22,15 @@ jobs:
         node: [20, 22, 24]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+          allow-external-fork-fallback: true
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,23 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      # Socket Firewall screens the dependency install below. setup-node above
+      # already wrote the npmjs.org registry config, so SFW is configured after
+      # it and before the first dependency download.
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+
       - name: Install Dependencies
         run: |
           pnpm install
+
+      # Restore the public npm registry after the final dependency download and
+      # before build and publication. Neither the build (tsup) nor the publish
+      # steps download further dependencies.
+      - name: Restore public package registry
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
 
       - name: Build project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Socket Firewall is configured before the pnpm manager setup so the
+      # package-manager bootstrap is covered too. setup-node below writes
+      # npmjs.org registry config, so the firewall is configured again after it.
+      - name: Configure Socket Firewall for pnpm manager
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
@@ -29,9 +38,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      # Socket Firewall screens the dependency install below. setup-node above
-      # already wrote the npmjs.org registry config, so SFW is configured after
-      # it and before the first dependency download.
+      # Re-apply after setup-node's registry-url mutation and before the
+      # dependency install. This keeps SFW active while preserving the public
+      # npm publish registry config for after teardown.
       - name: Configure Socket Firewall
         uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
         with:

--- a/.github/workflows/socket-tier1-analysis.yml
+++ b/.github/workflows/socket-tier1-analysis.yml
@@ -27,8 +27,20 @@ jobs:
           echo "distinct_id: ${{ github.event.inputs.distinct_id }}"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # Socket Firewall screens the Socket CLI download below. This scheduled
+      # job installs the CLI from the public npm registry, so SFW is configured
+      # before that download.
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
       - name: Install Socket CLI
         run: npm install -g socket
+      # Restore the public npm registry after the CLI install and before the
+      # scan. The scan uploads manifests to Socket and performs no further
+      # dependency downloads.
+      - name: Restore public package registry
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
       - name: Run Tier 1 reachability scan
         env:
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_API_KEY }}

--- a/.github/workflows/socket-tier1-analysis.yml
+++ b/.github/workflows/socket-tier1-analysis.yml
@@ -36,17 +36,18 @@ jobs:
           token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
       - name: Install Socket CLI
         run: npm install -g socket
-      # Restore the public npm registry after the CLI install and before the
-      # scan. The scan uploads manifests to Socket and performs no further
-      # dependency downloads.
-      - name: Restore public package registry
-        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
       - name: Run Tier 1 reachability scan
         env:
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_API_KEY }}
         run: |
-          # Full application reachability (Tier 1)
+          # Full application reachability (Tier 1). Keep Socket Firewall active
+          # because --reach can install missing project dependencies.
           socket scan create . \
             --reach \
             --org "workos" \
             --no-interactive
+      # Restore the public npm registry after the reachability scan. The scan
+      # can install missing project dependencies, so SFW stays active through it.
+      - name: Restore public package registry
+        if: ${{ always() }}
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1


### PR DESCRIPTION
This repository installs public npm packages in three GitHub Actions paths: ordinary CI, the package release workflow, and the scheduled Socket reachability scan. Before this change, the CI install was still unscreened, and the release workflow only covered the package install itself.

This change routes those dependency downloads through the WorkOS Socket Firewall. CI now runs with read-only `contents` permission, checks out without persisted credentials, and enables the action's validated external-fork fallback only for the ordinary public `pull_request` path. Same-repository pull requests and `main` pushes still fail closed when the public firewall token is unavailable.

The release workflow now configures the firewall before the pnpm manager setup, configures it again after `actions/setup-node` writes the npm registry setting, and tears it down immediately after `pnpm install`. The build and publish commands stay the same, including public access, trusted publishing provenance, latest/next tagging, and prerelease routing.

The scheduled Socket analysis still uses its separate Socket API token. Its npm CLI install is screened by the firewall, then the public registry is restored before the scan uploads manifests to Socket.

Verify by checking `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/socket-tier1-analysis.yml`, then run `actionlint .github/workflows/*.yml`.
